### PR TITLE
Support domains in the EU Region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ __pycache__/
 .Python
 env/
 .env/
+.venv/
+.vscode/
 bin/
 build/
 develop-eggs/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ from pymailgunner import Client
 mailgun_client = Client({api_key}, {domain_name})
 ```
 
+Or, for domains in the EU Region, 
+
+``` python
+from pymailgunner import Client
+
+mailgun_client = Client({api_key}, {domain_name}, eu_domain=True)
+```
+
 Features
 ========
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To create a mailgun Client you will need a mailgun api key and the domain name
 to use (must match the domain name registered on the mailgun website).
 
 ``` python
-from pymailgun import Client
+from pymailgunner import Client
 
 mailgun_client = Client({api_key}, {domain_name})
 ```

--- a/pymailgunner/client.py
+++ b/pymailgunner/client.py
@@ -32,7 +32,7 @@ class Client(object):
 
     @param key: The API key.
     @param domain: The domain to send mails from.
-    @param sanbox: Whether to use the sanbox domain in case the domain is not
+    @param sandbox: Whether to use the sandbox domain in case the domain is not
     provided.
     """
 

--- a/pymailgunner/client.py
+++ b/pymailgunner/client.py
@@ -34,11 +34,13 @@ class Client(object):
     @param domain: The domain to send mails from.
     @param sandbox: Whether to use the sandbox domain in case the domain is not
     provided.
+    @param eu_domain: Whether the domain is in the EU region
     """
 
-    def __init__(self, key, domain=None, sandbox=False):
+    def __init__(self, key, domain=None, sandbox=False, eu_domain=False):
         self._CACHE = {}  # Internal REST API response cache
         self.api_key = key
+        self.api_url = ('https://api.eu.mailgun.net/v2' if eu_domain else 'https://api.mailgun.net/v2')
         if not domain:
             domain = self.guess_domain(sandbox=sandbox)
         self.check_domain(domain)
@@ -100,7 +102,7 @@ class Client(object):
             if cache_index in self._CACHE:
                 logger.debug('Cache hit for index "{}"'.format(cache_index))
                 return self._CACHE[cache_index]
-        url = 'https://api.mailgun.net/v2/{}'.format(path)
+        url = '{}/{}'.format(self.api_url, path)
         auth = ('api', self.api_key)
         resp = requests.request(method, url, data=data, auth=auth, files=files)
         if resp.status_code == 401:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pymailgunner',
-    version='1.4',
+    version='1.5',
     author='Philipp Schmitt',
     author_email='philipp@schmitt.co',
     url='https://github.com/pschmitt/pymailgunner',


### PR DESCRIPTION
If a domain is in the EU Region, the base URL for the Mailgun API should be `https://api.eu.mailgun.net/` instead of `https://api.mailgun.net/` 

See the following [documentation](https://documentation.mailgun.com/en/latest/api-intro.html#base-url) for more information.

This pull request adds an additional (optional) argument to the `Client` constructor to use the base url for the EU region if desired.

e.g.

``` python
mailgun_client = Client({api_key}, {domain_name}, eu_domain=True)
```

It also includes some minor fixes and bumps the version to 1.5.

If these could be accepted, and the new version published to PyPi, then the [HomeAssistant component](https://github.com/home-assistant/home-assistant/tree/dev/homeassistant/components/mailgun) could be updated to support the argument too.
